### PR TITLE
Treat a elements with id tag as valid anchors

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -26,7 +26,7 @@ class Link
     if $link.is('a')
       @text = $link.text()
       @href = $link.attr('href')
-      @isAnchor = $link.attr('name')?.length > 0 and not @href?
+      @isAnchor = ($link.attr('name')?.length > 0 || $link.attr('id')?.length > 0) and not @href?
 
     else if $link.is('img')
       @text = $link.attr('alt')

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -117,6 +117,17 @@ describe 'Metalsmith plugin', ->
         expect(err).to.not.exist
         done()
 
+  it 'should allow anchors using the id tag when allowAnchors is set ', (done) ->
+    Metalsmith(__dirname)
+      .source './src-no-broken-links'
+      .use (files, metalsmith) ->
+        files['testfile.html'] = 
+          contents: new Buffer '<a id="anchorname">anchor</a>'
+      .use blc({allowAnchors: true})
+      .build (err) ->
+        expect(err).to.not.exist
+        done()
+
   it 'should not allow anchors when allowAnchors is not set', (done) ->
     Metalsmith(__dirname)
       .source './src-no-broken-links'


### PR DESCRIPTION
The HTML 5 spec allows for the 'id' attribute to function as the target of a fragment URL, e.g. <a id="foo">..</a>, <a href="#foo">link</a>.  This appears to be the current HTML 5 standard, superceding the 'name' attribute. More here: http://w3c.github.io/html/browsers.html#an-indicated-part-of-the-document