### PR TITLE
Decode link paths to match file names containing spaces

### DIFF
--- a/src/is-link-broken.js
+++ b/src/is-link-broken.js
@@ -65,7 +65,7 @@ module.exports = ({
 
   // Need to transform uri.path() into something Metalsmith can recognise
   const unixFilename = filename.replace(/\\/g, "/")
-  let linkPath = uri.absoluteTo(unixFilename).path()
+  let linkPath = decodeURIComponent(uri.absoluteTo(unixFilename).path())
 
   // If baseURL then all internal links should be prefixed by it.
   if (options.baseURL) {


### PR DESCRIPTION
This pull request fixes an issue we found where file names that contain spaces will cause the broken link checker to throw an error when we link to that file. This is because the link path consists of encoded spaces, and it needs to be decoded in order to match that of the file name.

[Example output](https://github.com/department-of-veterans-affairs/vets-website/pull/10470#issuecomment-515058325)