### PR TITLE
add option to write broken links to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Small typos can often result in *unexpected* broken links. This plugin aims to c
 
 It checks for *relative* and *root-relative* links which do not have a corresponding file in the Metalsmith pipeline. It (currently) ignores all *absolute* links.
 
-Any broken links will cause an `Error` to be thrown (or a warning to be printed if `options.warn` is set). 
+You can configure it to `Error` or log a warning or write to a file if any broken links are found.
 
 By default, all `href` attributes of `<a>` tags and all `src` attributes of `<img>` tags are checked. 
 
@@ -121,6 +121,10 @@ Metalsmith(__dirname)
 
 - If *false* then throw an `Error` when encountering the first broken link
 - If *true* then print warnings to stderr for every broken link
+
+#### `write_to_file` (optional, default: *false* )
+
+- If *true* then write all broken links to `broken_links.txt`.  This applies independently from the `warn` setting.
 
 #### `baseURL` (optional, default: *null* )
 

--- a/src/handle-links.js
+++ b/src/handle-links.js
@@ -1,9 +1,22 @@
+ var fs = require('fs');
+
 function maybeLog(log, links) {
   links.forEach((link) => {
     if (link.broken) {
       log(`${link.filename} >>> ${link.description}`)
     }
   })
+}
+
+function maybeWriteToFile(links) {
+  const brokenLinks = links.filter(({broken}) => !!broken)
+  const fileName = "broken_links.txt"
+  if (brokenLinks.length) {
+    const content = brokenLinks.map(link => `${link.filename} >>> ${link.description}`).join('\n')
+    fs.writeFile(fileName, content, (err) => { if(err) throw err } )
+  } else {
+    fs.existsSync(fileName) && fs.unlink(fileName, (err) => { if(err) throw err })
+  }
 }
 
 function maybeThrow(links) {
@@ -20,6 +33,8 @@ function maybeThrow(links) {
 
 module.exports = (options, log = console.log) => {
   return (links) => {
+    if (options.write_to_file) maybeWriteToFile(links)
+
     if (options.warn) {
       maybeLog(log, links)
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ module.exports = (options) => {
 
   if (options == null) { options = {} }
   if (options === true) { options = {} } // Allow CLI to specify true
+  if (options.write_to_file == null) { options.write_to_file = false }
   if (options.warn == null) { options.warn = false }
   if (options.checkLinks == null) { options.checkLinks = true }
   if (options.checkImages == null) { options.checkImages = true }


### PR DESCRIPTION
Hi David.  I started using this library and realized I knew you.  So thanks!

I added a simple option to write broken links to a file.  I find this useful for my workflow because sometimes I miss warnings, but an extra file is hard to miss when I'm ready to make a commit.

I'm not sure if you are maintaining this library any more, but I thought I'd made a PR anyway for posterity.

All the best!